### PR TITLE
Poprawki - nazwy namespace i class

### DIFF
--- a/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja.Android/Inwentaryzacja.Android.csproj
+++ b/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja.Android/Inwentaryzacja.Android.csproj
@@ -65,6 +65,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
   </ItemGroup>
   <ItemGroup>
+    <AndroidAsset Include="Assets\Comfortaa-VariableFont_wght.ttf" />
+    <AndroidAsset Include="Assets\Roboto-Light.ttf" />
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Properties\AndroidManifest.xml" />

--- a/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/App.xaml.cs
+++ b/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/App.xaml.cs
@@ -11,7 +11,7 @@ namespace Inwentaryzacja
         {
             InitializeComponent();
 
-            MainPage = new MainPage();
+            MainPage = new WelcomeViewPage();
         }
 
         protected override void OnStart()

--- a/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/WelcomeViewPage.xaml
+++ b/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/WelcomeViewPage.xaml
@@ -4,7 +4,7 @@
              xmlns:d="http://xamarin.com/schemas/2014/forms/design"
              xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006" xmlns:local="clr-namespace:Inwentaryzacja"
              mc:Ignorable="d"
-             x:Class="WidokPowitalny.WidokPowitalny"
+             x:Class="Inwentaryzacja.WelcomeViewPage"
              BackgroundColor="#8EE3BA">
 
     <ContentPage.Content>

--- a/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/WelcomeViewPage.xaml.cs
+++ b/Inwentaryzacja/Inwentaryzacja/Inwentaryzacja/WelcomeViewPage.xaml.cs
@@ -7,12 +7,12 @@ using System.Threading.Tasks;
 using Xamarin.Forms;
 using Xamarin.Forms.Xaml;
 
-namespace WidokPowitalny
+namespace Inwentaryzacja
 {
     [XamlCompilation(XamlCompilationOptions.Compile)]
-    public partial class WidokPowitalny : ContentPage
+    public partial class WelcomeViewPage : ContentPage
     {
-        public WidokPowitalny()
+        public WelcomeViewPage()
         {
             InitializeComponent();
         }


### PR DESCRIPTION
Widzę, że nazwę widoku nadałeś poprawną, ale potem zacząłeś używać innej (polskiej). Żeby nie robić bałaganu to wszystkie nazwy dajemy po angielsku. Trochę nie wiem dlaczego to działało, bo namespace polski w ogóle nie miał metody InitializeComponent() i VS od razu mi to podpowiedział. Dziwne, że nie prowadziło to do błędu kompilacji. Ten commit poprawia te rzeczy.

Osobna sprawa jest taka, że ten widok trochę inaczej u mnie wygląda na emulatorze niż na tym screenie. Na moim telefonie wygląda tak jak na emulatorze, czyli tak. Trochę za dużo przestrzeni między nagłówkiem i guzikami:

![obraz](https://user-images.githubusercontent.com/45820576/79012544-d5149d00-7b66-11ea-8df8-dab9a434561d.png)
